### PR TITLE
Left alignment fix

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 # Release Notes
 
-## Version 0.2.1 (2025-01-13)
+## Version 0.2.2 (2025-06-16 )
+
+- fix left alignment issue with inputs in the presence of outside css influences
+
+## Version 0.2.1 
 
 ### 🔧 UI/UX Improvements
 
@@ -44,7 +48,7 @@ While v0.2.0 introduced major features like enum support and compact mode, v0.2.
 
 ---
 
-## Version 0.2.0 (2025-01-06)
+## Version 0.2.0 
 
 ### 🎉 Major Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fh-pydantic-form"
-version = "0.2.1"
+version = "0.2.2"
 description = "a library to turn any pydantic BaseModel object into a fasthtml/monsterui input form"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/fh_pydantic_form/field_renderers.py
+++ b/src/fh_pydantic_form/field_renderers.py
@@ -354,9 +354,9 @@ class BooleanFieldRenderer(BaseFieldRenderer):
             fh.Div(
                 label_component,
                 checkbox_component,
-                cls="flex items-center gap-2",  # Use flexbox to align items horizontally with a small gap
+                cls="flex items-center gap-2 w-full",  # Use flexbox to align items horizontally with a small gap
             ),
-            cls=spacing("outer_margin", self.spacing),
+            cls=f"{spacing('outer_margin', self.spacing)} w-full",
         )
 
 
@@ -672,7 +672,7 @@ class BaseModelFieldRenderer(BaseFieldRenderer):
             id=accordion_id,  # ID for the accordion container (ul)
             multiple=True,  # Allow multiple open (though only one exists)
             collapsible=True,  # Allow toggling
-            cls=f"{spacing('accordion_divider', self.spacing)} {spacing('accordion_content', self.spacing)}".strip(),
+            cls=f"{spacing('accordion_divider', self.spacing)} {spacing('accordion_content', self.spacing)} w-full".strip(),
         )
 
         return accordion_container
@@ -929,7 +929,7 @@ class ListFieldRenderer(BaseFieldRenderer):
         return fh.Div(
             label_with_icon,
             self.render_input(),
-            cls=spacing("outer_margin", self.spacing),
+            cls=f"{spacing('outer_margin', self.spacing)} w-full",
         )
 
     def render_input(self) -> FT:

--- a/src/fh_pydantic_form/field_renderers.py
+++ b/src/fh_pydantic_form/field_renderers.py
@@ -214,9 +214,9 @@ class BaseFieldRenderer:
                 fh.Div(
                     label_component,
                     input_component,
-                    cls=f"flex {spacing('horizontal_gap', self.spacing)} {spacing('label_align', self.spacing)}",
+                    cls=f"flex {spacing('horizontal_gap', self.spacing)} {spacing('label_align', self.spacing)} w-full",
                 ),
-                cls=spacing("outer_margin", self.spacing),
+                cls=f"{spacing('outer_margin', self.spacing)} w-full",
             )
         else:
             # Vertical layout for normal mode (existing behavior)

--- a/src/fh_pydantic_form/ui_style.py
+++ b/src/fh_pydantic_form/ui_style.py
@@ -72,7 +72,7 @@ SPACING_MAP: Dict[SpacingTheme, Dict[str, str]] = {
         "input_size": "uk-form-small",
         "input_padding": "p-1",
         "horizontal_gap": "gap-2",
-        "label_align": "items-center",
+        "label_align": "items-start",
     },
 }
 
@@ -88,6 +88,26 @@ def spacing(token: str, spacing: SpacingValue) -> str:
 COMPACT_EXTRA_CSS = fh.Style("""
 /* Compact polish – applies ONLY inside .fhpf-compact ------------------- */
 .fhpf-compact {
+  /* Force full width and left alignment */
+  width: 100% !important;
+  
+  /* Ensure all direct children are full width and left aligned */
+  & > * {
+    width: 100% !important;
+    justify-content: flex-start !important;
+    align-items: flex-start !important;
+  }
+  
+  /* Target the field containers specifically */
+  & > div > div {
+    width: 100% !important;
+    justify-content: flex-start !important;
+  }
+  
+  /* Ensure flex containers don't center */
+  .flex {
+    justify-content: flex-start !important;
+  }
 
   /* Accordion chrome: remove border and default 20 px gap */
   .uk-accordion > li,


### PR DESCRIPTION
forces left alignment for inputs. Without this fix sometimes inputs get centered in compact mode depending on the presence of other css in the fasthtml app. 