### PR TITLE
Fix ty suppression comment syntax

### DIFF
--- a/examples/annotation_app.py
+++ b/examples/annotation_app.py
@@ -111,7 +111,9 @@ SAMPLE_DOCUMENTS = {
 
 def insert_sample_documents():
     for doc_id, doc_data in SAMPLE_DOCUMENTS.items():
-        initial_annotation: DocumentExtraction = doc_data["initial_extraction"]  # type: ignore[invalid-assignment]
+        initial_annotation: DocumentExtraction = doc_data[
+            "initial_extraction"
+        ]  # ty: ignore[invalid-assignment]
         annotations.upsert(
             {
                 "document_id": doc_id,

--- a/examples/complex_example.py
+++ b/examples/complex_example.py
@@ -173,9 +173,13 @@ class ComplexSchema(BaseModel):
     )
 
     # List[Literal] - renders as pills with dropdown (NEW!)
-    selected_regions: List[Literal["EMEA", "APAC", "AMERICAS", "OTHER"]] = Field(
-        default_factory=lambda: ["EMEA"],
-        description="Selected regions for the customer (pill/tag selector)",
+    selected_regions: List[
+        Literal["EMEA", "APAC", "AMERICAS", "OTHER"]
+    ] = (  # ty: ignore[invalid-assignment]
+        Field(
+            default_factory=lambda: ["EMEA"],
+            description="Selected regions for the customer (pill/tag selector)",
+        )
     )
 
     # List[Enum] - also renders as pills with dropdown (NEW!)

--- a/tests/comparison/test_comparison_skip_json_fields.py
+++ b/tests/comparison/test_comparison_skip_json_fields.py
@@ -65,12 +65,12 @@ class TestComparisonFormSkipJsonSchema:
             )
 
             # Nested models with SkipJsonSchema fields
-            main_address: address_model = Field(  # type: ignore[invalid-type-form]
+            main_address: address_model = Field(  # ty: ignore[invalid-type-form]
                 default_factory=address_model,
                 description="Main address",
             )
-            other_addresses: List[address_model] = Field(  # type: ignore[invalid-type-form]
-                default_factory=list, description="Other addresses"
+            other_addresses: List[address_model] = (  # ty: ignore[invalid-type-form]
+                Field(default_factory=list, description="Other addresses")
             )
 
         return CustomerData

--- a/tests/test_initial_values_robustness.py
+++ b/tests/test_initial_values_robustness.py
@@ -441,7 +441,9 @@ class TestEdgeCases:
     def test_circular_reference_handling(self, simple_test_model):
         """Test handling of dictionaries with circular references."""
         circular_dict = {"name": "Circular User", "age": 30}
-        circular_dict["self"] = circular_dict  # type: ignore[invalid-assignment]  # Circular reference
+        circular_dict["self"] = (
+            circular_dict  # ty: ignore[invalid-assignment]  # Circular reference
+        )
 
         # Should not crash during construction
         form = PydanticForm("test", simple_test_model, initial_values=circular_dict)

--- a/tests/test_skip_json_schema_fields.py
+++ b/tests/test_skip_json_schema_fields.py
@@ -44,7 +44,7 @@ class TestSkipJsonSchemaIntegration:
     ) -> Type[BaseModel]:
         """User model inheriting from DocumentBase."""
 
-        class UserDocument(document_base_model):  # type: ignore[unsupported-base]
+        class UserDocument(document_base_model):  # ty: ignore[unsupported-base]
             name: str = Field(description="User's full name")
             email: str = Field(description="User's email address")
             age: Optional[int] = Field(None, description="User's age")
@@ -68,7 +68,7 @@ class TestSkipJsonSchemaIntegration:
                 default_factory=lambda: str(uuid4()), description="Internal address ID"
             )
 
-        class ComplexDocument(document_base_model):  # type: ignore[unsupported-base]
+        class ComplexDocument(document_base_model):  # ty: ignore[unsupported-base]
             title: str
             content: str
             author: str


### PR DESCRIPTION
## Summary
- CI has been failing on all scheduled runs since ~March 29 because `ty` was updated and no longer recognizes mypy-style `# type: ignore[rule-name]` comments
- Changed to `# ty: ignore[rule-name]` which is ty's own suppression syntax, across 5 files (7 diagnostics)
- Added missing suppression for `complex_example.py:176` which was never suppressed

## Test plan
- [x] `uv run ty check` passes locally
- [x] `uv run prek run -a` passes locally
